### PR TITLE
feat: Secure EC2 launch templates with IMDSv2

### DIFF
--- a/packages/cdk/lib/constructs/batch.ts
+++ b/packages/cdk/lib/constructs/batch.ts
@@ -248,6 +248,10 @@ export class Batch extends Construct {
         launchTemplateData: {
           userData: Fn.base64(launchTemplateData),
           tagSpecifications,
+          metadataOptions: {
+            httpTokens: "required",
+            httpPutResponseHopLimit: 2,
+          },
         },
       };
     }


### PR DESCRIPTION
**Description of Changes**

Add metadataOptions to require IMDSv2. This is a security best practice to prevent credential hijacking and will keep the EC2s generated by this application from drawing the ire of security teams.